### PR TITLE
Add explicit workflow permissions for PR approval

### DIFF
--- a/.github/workflows/renovate-auto-merge.yaml
+++ b/.github/workflows/renovate-auto-merge.yaml
@@ -5,7 +5,8 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  pull-requests: write
+  contents: write # Allows the workflow to write to the repository
+  pull-requests: write # Allows the workflow to create and approve pull requests
 
 jobs:
   auto-approve:


### PR DESCRIPTION
- Add contents: write and pull-requests: write permissions
- Organization settings may be blocking default permissions
- Use explicit permissions to allow PR approvals