### PR TITLE
Try dedicated auto-approve action and expanded permissions

### DIFF
--- a/.github/workflows/renovate-auto-merge.yaml
+++ b/.github/workflows/renovate-auto-merge.yaml
@@ -5,8 +5,11 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: write # Allows the workflow to write to the repository
-  pull-requests: write # Allows the workflow to create and approve pull requests
+  contents: write
+  pull-requests: write
+  actions: read
+  checks: read
+  repository-projects: read
 
 jobs:
   auto-approve:
@@ -15,19 +18,6 @@ jobs:
     
     steps:
       - name: Auto-approve PR
-        uses: actions/github-script@v7
+        uses: hmarr/auto-approve-action@v4
         with:
-          script: |
-            try {
-              await github.rest.pulls.createReview({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number,
-                event: 'APPROVE',
-                body: 'Auto-approved Renovate dependency update (merge handled by GitHub auto-merge settings)'
-              });
-              console.log('PR approved successfully');
-            } catch (error) {
-              console.log('Error approving PR:', error.message);
-              // Continue anyway, approval might not be required
-            }
+          review-message: 'Auto-approved Renovate dependency update (merge handled by GitHub auto-merge settings)'


### PR DESCRIPTION
- Use hmarr/auto-approve-action@v4 instead of github-script
- Add additional read permissions (actions, checks, repository-projects)
- Dedicated approval actions may handle org restrictions better